### PR TITLE
Fixes #6: Preflight requests can be terminated and returned immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,5 @@ http-response lua.cors
 You can also whitelist all domains by setting the second parameter to an asterisk:
 
 ```
-http-response lua.cors "GET,PUT,POST" "*"
+http-request lua.cors "GET,PUT,POST" "*"
 ```

--- a/README.md
+++ b/README.md
@@ -29,16 +29,16 @@ global
     lua-load /path/to/cors.lua
 ```
 
-In your `frontend` or `listen` section, capture the client's *Origin* request header by adding `http-request lua.cors`:
+In your `frontend` or `listen` section, capture the client's *Origin* request header by adding `http-request lua.cors` The first parameter is a comma-delimited list of HTTP methods that can be used. The second parameter is comma-delimited list of origins that are permitted to call your service.
 
 ```
-http-request lua.cors
+http-request lua.cors "GET,PUT,POST" "example.com,localhost,localhost:8080"
 ```
 
-Within the same section, invoke the `http-response lua.cors` action. The first parameter is a a comma-delimited list of HTTP methods that can be used. The second parameter is comma-delimited list of origins that are permitted to call your service.
+Within the same section, invoke the `http-response lua.cors` action to attach CORS headers to responses from backend servers.
 
 ```
-http-response lua.cors "GET,PUT,POST" "example.com,localhost,localhost:8080"
+http-response lua.cors 
 ```
 
 You can also whitelist all domains by setting the second parameter to an asterisk:

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     - "name=server1"
 
   haproxy:
-    image: haproxytech/haproxy-ubuntu:2.0
+    image: haproxytech/haproxy-ubuntu:2.2
     volumes:
     - "./haproxy/haproxy.cfg:/etc/haproxy/haproxy.cfg"
     - "./haproxy/cors.lua:/etc/haproxy/cors.lua"

--- a/example/haproxy/haproxy.cfg
+++ b/example/haproxy/haproxy.cfg
@@ -19,8 +19,8 @@ listen api
     bind :8080
 
     # Invoke the CORS service on the request to capture the Origin header
-    http-request lua.cors
+    http-request lua.cors "GET,PUT,POST", "localhost"
 
     # Invoke the CORS service on the response to add CORS headers
-    http-response lua.cors "GET,PUT,POST" "localhost"
+    http-response lua.cors
     server s1 server1:80 check

--- a/lib/cors.lua
+++ b/lib/cors.lua
@@ -20,35 +20,93 @@ function contains(items, test_str)
   return false
 end
 
--- When invoked during a request, captures the Origin header if present
--- and stores it in a private variable.
-function cors_request(txn)
+-- If the given origin is found within the allowed_origins string, it is returned. Otherwise, nil is returned.
+-- origin: The value from the 'origin' request header
+-- allowed_methods: Comma-delimited list of allowed HTTP methods. (e.g. GET,POST,PUT,DELETE)
+function get_allowed_origin(origin, allowed_origins)
+  if origin ~= nil then
+    local allowed_origins = core.tokenize(allowed_origins, ",")
+
+    -- Strip whitespace
+    for index, value in ipairs(allowed_origins) do
+      allowed_origins[index] = value:gsub("%s+", "")
+    end
+
+    core.Debug("CORS - Origin: " .. origin)
+
+    if contains(allowed_origins, "*") then
+      return "*"
+    elseif contains(allowed_origins, origin:match("//([^/]+)")) then
+      return origin
+    end
+  end
+
+  return nil
+end
+
+-- Add headers for CORS preflight request and then returns a 204 response.
+-- txn: The current transaction object that gives access to response properties
+-- method: The HTTP method
+-- origin: The value from the 'origin' request header
+-- allowed_methods: Comma-delimited list of allowed HTTP methods. (e.g. GET,POST,PUT,DELETE)
+-- allowed_origins: Comma-delimited list of allowed origins. (e.g. localhost,localhost:8080,test.com)
+function preflight_request(txn, method, origin, allowed_methods, allowed_origins)
+  core.Debug("CORS: preflight request OPTIONS")
+
+  -- NOTE: The 'reply' function is available in HAProxy 2.2+
+  local reply = txn:reply()
+  reply:set_status(204, "No Content")
+  reply:add_header("Content-Type", "text/html")
+  reply:add_header("Access-Control-Allow-Methods", allowed_methods)
+  reply:add_header("Access-Control-Max-Age", 600)
+
+  local allowed_origin = get_allowed_origin(origin, allowed_origins)
+
+  if allowed_origin == nil then
+    core.Debug("CORS: " .. origin .. " not allowed")
+  else
+    core.Debug("CORS: " .. origin .. " allowed")
+    reply:add_header("Access-Control-Allow-Origin", allowed_origin)
+  end
+
+  core.Debug("CORS: Returning reply to CORS preflight request")
+  txn:done(reply)
+end
+
+-- When invoked during a request, captures the origin header if present and stores it in a private variable.
+-- If the request is OPTIONS, returns a preflight request reply.
+-- txn: The current transaction object that gives access to response properties
+-- allowed_methods: Comma-delimited list of allowed HTTP methods. (e.g. GET,POST,PUT,DELETE)
+-- allowed_origins: Comma-delimited list of allowed origins. (e.g. localhost,localhost:8080,test.com)
+function cors_request(txn, allowed_methods, allowed_origins)
   local headers = txn.http:req_get_headers()
-  local origin = headers["origin"]
+  local origin = headers["origin"][0]
+
+  local transaction_data = {}
 
   if origin ~= nil then
     core.Debug("CORS: Got 'Origin' header: " .. headers["origin"][0])
-    txn:set_priv(headers["origin"][0])
+    transaction_data["origin"] = origin
   end
-end
 
--- Add headers for CORS preflight request
-function preflight_request(txn, method, allowed_methods)
-  if method == "OPTIONS" then
-    core.Debug("CORS: preflight request OPTIONS")
-    txn.http:res_add_header("Access-Control-Allow-Methods", allowed_methods)
-    txn.http:res_add_header("Access-Control-Max-Age", 600)
-  end
-end
+  transaction_data["allowed_methods"] = allowed_methods
+  transaction_data["allowed_origins"] = allowed_origins
 
--- When invoked during a response, sets CORS headers so that the browser
--- can read the response from permitted domains.
--- txn: The current transaction object that gives access to response properties.
--- allowed_methods: Comma-delimited list of allowed HTTP methods. (e.g. GET,POST,PUT,DELETE)
--- allowed_origins: Comma-delimited list of allowed origins. (e.g. localhost,localhost:8080,test.com)
-function cors_response(txn, allowed_methods, allowed_origins)
+  txn:set_priv(transaction_data)
+
   local method = txn.sf:method()
-  local origin = txn:get_priv()
+
+  if method == "OPTIONS" then
+    preflight_request(txn, method, origin, allowed_methods, allowed_origins)
+  end
+end
+
+-- When invoked during a response, sets CORS headers so that the browser can read the response from permitted domains.
+-- txn: The current transaction object that gives access to response properties.
+function cors_response(txn)
+  local transaction_data = txn:get_priv()
+  local origin = transaction_data["origin"]
+  local allowed_origins = transaction_data["allowed_origins"]
 
   -- Always vary on the Origin
   txn.http:res_add_header("Vary", "Accept-Encoding,Origin")
@@ -58,26 +116,16 @@ function cors_response(txn, allowed_methods, allowed_origins)
     return
   end
 
-  local allowed_origins = core.tokenize(allowed_origins, ",")
+  local allowed_origin = get_allowed_origin(origin, allowed_origins)
 
-  -- Strip whitespace
-  for index, value in ipairs(allowed_origins) do
-    allowed_origins[index] = value:gsub("%s+", "")
-  end  
-
-  if contains(allowed_origins, "*") then
-    core.Debug("CORS: " .. "* allowed")
-    txn.http:res_add_header("Access-Control-Allow-Origin", "*")
-    preflight_request(txn, method, allowed_methods)
-  elseif contains(allowed_origins, origin:match("//([^/]+)")) then
-    core.Debug("CORS: " .. origin .. " allowed")
-    txn.http:res_add_header("Access-Control-Allow-Origin", origin)
-    preflight_request(txn, method, allowed_methods)
-  else
+  if allowed_origin == nil then
     core.Debug("CORS: " .. origin .. " not allowed")
+  else
+    core.Debug("CORS: " .. origin .. " allowed")
+    txn.http:res_add_header("Access-Control-Allow-Origin", allowed_origin)
   end
 end
 
 -- Register the actions with HAProxy
-core.register_action("cors", {"http-req"}, cors_request, 0)
-core.register_action("cors", {"http-res"}, cors_response, 2)
+core.register_action("cors", {"http-req"}, cors_request, 2)
+core.register_action("cors", {"http-res"}, cors_response, 0)


### PR DESCRIPTION
With this change, the module will now intercept preflight requests (OPTIONS requests) and return an immediate reply without contacting the backend servers. **This is only supported in HAProxy version 2.2 and above.** In older versions, it reverts to the previous behavior of forwarding the preflight request to the backend server and then attaching the CORS headers on the response on its way back out.

Note that this changes the syntax you must use in the `haproxy.cfg`. Now, all needed info is collected on the request action, saved in a table that is stored in a private variable, and then retrieved during the response.

example:

```
# Invoke the CORS service on the request to capture the Origin header
http-request lua.cors "GET,PUT,POST", "localhost"

# Invoke the CORS service on the response to add CORS headers
http-response lua.cors
```