### PR TITLE
Additional Origin from HAProxy configuration

### DIFF
--- a/example/haproxy/haproxy.cfg
+++ b/example/haproxy/haproxy.cfg
@@ -21,6 +21,9 @@ listen api
     # Log the Origin header
     http-request capture req.hdr(Origin) len 20
 
+    # Additional Origin from HAProxy configuration
+    http-request set-var(txn.custom_allowed_origins) req.hdr(X-Extra-Host)
+
     # Invoke the CORS service on the request to capture the Origin header
     http-request lua.cors "GET,PUT,POST" "localhost" "X-Custom-Header"
 

--- a/lib/cors.lua
+++ b/lib/cors.lua
@@ -175,7 +175,13 @@ function cors_request(txn, allowed_methods, allowed_origins, allowed_headers)
   local transaction_data = {}
   local origin = nil
   local allowed_origins = core.tokenize(allowed_origins, ",")
-  
+  local custom_allowed_origins = txn.get_var(txn, 'txn.custom_allowed_origins')
+
+  if custom_allowed_origins ~= nil and custom_allowed_origins ~= '' then
+    core.Debug("CORS: Got 'custom_allowed_origins' var: " .. custom_allowed_origins)
+    table.insert(allowed_origins, custom_allowed_origins)
+  end
+
   if headers["origin"] ~= nil and headers["origin"][0] ~= nil then
     core.Debug("CORS: Got 'Origin' header: " .. headers["origin"][0])
     origin = headers["origin"][0]


### PR DESCRIPTION
Hello!

We need to add to the list of allowed origins some hostnames from custom headers, so here are a few rows of code to do this. Maybe it would be helpful to somebody, or please suggest some other way to do the same without modification of the script.

Thanks in advance! Thanks for your job!